### PR TITLE
Add Support for PETSc with Complex Numbers

### DIFF
--- a/jax_fem/problem.py
+++ b/jax_fem/problem.py
@@ -404,7 +404,7 @@ class Problem:
             return values
 
     def compute_residual_vars_helper(self, weak_form_flat, weak_form_face_flat):
-        res_list = [np.zeros((fe.num_total_nodes, fe.vec)) for fe in self.fes]
+        res_list = [np.zeros((fe.num_total_nodes, fe.vec), dtype=weak_form_flat.dtype) for fe in self.fes]
         weak_form_list = jax.vmap(lambda x: self.unflatten_fn_dof(x))(weak_form_flat) # [(num_cells, num_nodes, vec), ...]
         res_list = [res_list[i].at[self.cells_list[i].reshape(-1)].add(weak_form_list[i].reshape(-1, 
             self.fes[i].vec)) for i in range(self.num_vars)]

--- a/jax_fem/solver.py
+++ b/jax_fem/solver.py
@@ -36,6 +36,13 @@ def jax_solve(A, b, x0, precond):
     A = BCOO.from_scipy_sparse(A_sp_scipy).sort_indices()
     jacobi = np.array(A_sp_scipy.diagonal())
     pc = lambda x: x * (1. / jacobi) if precond else None
+    
+    if issubclass(PETSc.ScalarType, np.complexfloating):
+        logger.debug("JAX Solver - Using PETSc with complex number support")
+        A = A.astype(complex)
+        b = b.astype(complex)
+        x0 = x0.astype(complex)
+
     x, info = jax.scipy.sparse.linalg.bicgstab(A,
                                                b,
                                                x0=x0,


### PR DESCRIPTION
### Summary
This PR adds support for using PETSc with complex scalar types, enabling complex-valued finite element computations. The implementation ensures compatibility with both real and complex PETSc installations.

### Changes
- Modified dtype handling to support `numpy.complex128` scalar types
- Updated array initialization to respect PETSc's scalar type configuration
- Ensured consistent dtype usage across weak form computations

### Installation Instructions

To use this feature, you must install PETSc compiled with complex number support:

#### 1. Install PETSc Complex (macOS with Homebrew)
```bash
brew install petsc-complex
```

#### 2. Install Python Dependencies
```bash
# Install petsc4py matching your PETSc version
uv pip install petsc==3.23.7

# Set environment variables to point to petsc-complex
export PETSC_DIR=$(brew --prefix petsc-complex)
export PETSC_ARCH=""

# Clean install petsc4py
uv pip install petsc4py==3.23.7 --no-cache-dir
```

#### 3. Verify Installation
You should see the following output during installation:
```
DEBUG PETSC_DIR:    /opt/homebrew/opt/petsc-complex
DEBUG PETSC_ARCH:   
DEBUG version:      3.23.7 release
DEBUG integer-size: 32-bit
DEBUG scalar-type:  complex
DEBUG precision:    double
DEBUG language:     CONLY
DEBUG compiler:     mpicc
DEBUG linker:       mpicc
```

Verify in Python:
```python
from petsc4py import PETSc
import numpy as np

print(f"PETSc Scalar Type: {PETSc.ScalarType}")  # Should be numpy.complex128
```

### Testing
- [ ] Tested with real-valued PETSc installation (backward compatibility)
- [x] Tested with complex-valued PETSc installation
- [x] Verified dtype consistency across all computations

### Notes
- This change is **backward compatible** - the code will work with both real and complex PETSc installations
- Complex number support is essential for acoustic and electromagnetic simulations