### PR TITLE
Fix: Check for None before casting with complex PETCs

### DIFF
--- a/jax_fem/solver.py
+++ b/jax_fem/solver.py
@@ -41,7 +41,8 @@ def jax_solve(A, b, x0, precond):
         logger.debug("JAX Solver - Using PETSc with complex number support")
         A = A.astype(complex)
         b = b.astype(complex)
-        x0 = x0.astype(complex)
+        if x0 is not None:
+            x0 = x0.astype(complex)
 
     x, info = jax.scipy.sparse.linalg.bicgstab(A,
                                                b,


### PR DESCRIPTION
#### Changes
Check if  `x0` is `None` before casting to complex values in function `jax_solve(A, b, x0, precond)`. This can happen when inverse problems are considered and `jax_solve(...)` is called from

```
adjoint_vec = linear_solver(A.transpose(), v_vec, None, adjoint_solver_options)
```
inside `def implicit_vjp(...)` in `solver.py`

This is a fix for changes made in https://github.com/deepmodeling/jax-fem/pull/72 implementing support for PETSc with complex number.