### PR TITLE
Fix typo in periodic boundary condition description

### DIFF
--- a/docs/source/advanced/adv_main.md
+++ b/docs/source/advanced/adv_main.md
@@ -5,7 +5,7 @@ Overview
 | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | [Arc length methods](https://github.com/deepmodeling/jax-fem/tree/main/applications/arc_length) | ${\color{green}Advanced\ solvers:}$ The arc-length control method for solving nonlinear structural mechanics problems with buckling behaviors. |
 | [Dynamic relaxation solver](https://github.com/deepmodeling/jax-fem/tree/main/applications/dynamic_relaxation) | ${\color{green}Advanced\ solvers:}$ The dynamic relaxation solver for solving nonlinear structural mechanics problems  with buckling behaviors. |
-| [Periodic B.C.](https://github.com/deepmodeling/jax-fem/tree/main/applications/periodic_bc) | ${\color{brown}Boundary\ conditions:}$ Linear multipoint constraint for periodci B.C.. |
+| [Periodic B.C.](https://github.com/deepmodeling/jax-fem/tree/main/applications/periodic_bc) | ${\color{brown}Boundary\ conditions:}$ Linear multipoint constraint for periodic B.C.. |
 | [Robin B.C.](https://github.com/deepmodeling/jax-fem/tree/main/applications/robin_bc) | ${\color{brown}Boundary\ conditions:}$ Robin/mixed boundary condition implementation. |
 | [Quiet element](https://github.com/deepmodeling/jax-fem/tree/main/applications/quiet_element) | ${\color{orange}Domain\ Control:}$ For element activation and de-activation. |
 | [Stokes equation](https://github.com/deepmodeling/jax-fem/tree/main/applications/stokes) | ${\color{red}Multiphysics:}$ Incompressible Stokes flow solver with mixed finite element formulation for velocity-pressure coupling. |


### PR DESCRIPTION
Periodic is misspelled as "periodci" in advanced documentation.


<img width="1437" height="957" alt="image" src="https://github.com/user-attachments/assets/90fb0631-1165-47a5-bb79-657b070e337f" />


Typo is corrected in the docs in this PR.